### PR TITLE
Allow overriding the region when invoking `loadConfig()`

### DIFF
--- a/src/aws-common.ts
+++ b/src/aws-common.ts
@@ -10,8 +10,13 @@ export function getSharedIniFileCredentialsFromAwsProfileIfDefined(
 
 export function loadConfig({
   awsProfile,
-}: { awsProfile?: string } = {}): AWS.Config {
+  options,
+}: {
+  awsProfile?: string
+  options?: Partial<AWS.ConfigurationOptions>
+} = {}): AWS.Config {
   return new AWS.Config({
+    ...options,
     credentials: getSharedIniFileCredentialsFromAwsProfileIfDefined(awsProfile),
   })
 }


### PR DESCRIPTION
This is useful when using the function for other purposes, such as initializing a Lambda client.